### PR TITLE
fix typos in page front matter

### DIFF
--- a/_episodes/00-before-we-start.md
+++ b/_episodes/00-before-we-start.md
@@ -10,9 +10,9 @@ objectives:
   - "Saber donde buscar ayuda."
   - "Demostrar como proporcionar suficiente información para solucionar problemas junto con la comunidad de usuarios de Python."
 keypoints:
-  - "Python es un lenguaje de programación de código libre y plataforma independiente"
-  - "SciPy es un ecosistema para Python que provee las herramientas necesarias para la computación científica"
-  - "Jupyter Notebook y la Spyder IDE son excelentes herramientas para escribir código e interactuar con Python. Con su gran comunidad es fácil encontrar ayuda en internet"
+  - "Python es un lenguaje de programación de código libre y plataforma independiente."
+  - "SciPy es un ecosistema para Python que provee las herramientas necesarias para la computación científica."
+  - "Jupyter Notebook y la Spyder IDE son excelentes herramientas para escribir código e interactuar con Python. Con su gran comunidad es fácil encontrar ayuda en internet."
 ---
 
 

--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -11,11 +11,11 @@ objectives:
     - "Realizar operaciones matemáticas en Python utilizando operadores básicos."
     - "Dentro del contexto de Python definir: **listas**, **tuplas**, y **diccionarios**."
 keypoints:
-    - "Python es un lenguaje interpretado que puede ser usado interactivamente (ejecutando un comando a la vez) o en modo scripting (ejecutando una serie de comandos guardados en un archivo)".
-    - "Se puede asignar un valor a una variable en Python. Esas variables pueden ser de varios tipos, tales como cadenas, y números: enteros, de punto flotante y complejos".
-    - "Las listas y las tuplas son similares en el sentido de que son listas ordenadas de elementos; difieren en que una tupla es inmutable (sus elementos no pueden ser modificados)".
+    - "Python es un lenguaje interpretado que puede ser usado interactivamente (ejecutando un comando a la vez) o en modo scripting (ejecutando una serie de comandos guardados en un archivo)."
+    - "Se puede asignar un valor a una variable en Python. Esas variables pueden ser de varios tipos, tales como cadenas, y números: enteros, de punto flotante y complejos."
+    - "Las listas y las tuplas son similares en el sentido de que son listas ordenadas de elementos; difieren en que una tupla es inmutable (sus elementos no pueden ser modificados)."
     - "Los diccionarios son estructuras de datos desordenadas que proporcionan mapeos entre claves y valores."
-  
+
 ---
 
 ## Intérprete
@@ -185,7 +185,7 @@ Data Carpentry
 Nota que "Data Carpentry" se imprime una vez.
 
 **Sugerencia**: `print` y `type` son funciones incorporadas en Python. Más adelante en esta
-lección, veremos métodos y funciones definidas por el usuario. La documentación 
+lección, veremos métodos y funciones definidas por el usuario. La documentación
 de Python es excelente para darte una referencia sobre las diferencias entre ellos.
 
 
@@ -289,7 +289,7 @@ numbers[0]
 ~~~
 {: .output}
 
-Se puede usar un bucle `for` para acceder a los elementos de una lista u otras 
+Se puede usar un bucle `for` para acceder a los elementos de una lista u otras
 estructuras de datos de Python, uno a la vez:
 
 ~~~
@@ -308,8 +308,8 @@ estructuras de datos de Python, uno a la vez:
 
 Usar **sangría** es muy importante en Python. Ten en cuenta que la segunda línea en el
 ejemplo de arriba está sangrada (o indentada). Al igual que los tres `>>>` son un
-indicador interactivo en Python, los tres puntos `...` son indicadores de 
-líneas multiples en Python. Esta es la manera en que Python marca un bloque de código. [Nota: no 
+indicador interactivo en Python, los tres puntos `...` son indicadores de
+líneas multiples en Python. Esta es la manera en que Python marca un bloque de código. [Nota: no
 tienes que escribir `>>>` o `...`.]
 
 Para agregar elementos al final de una lista, podemos usar el método `append`. Los métodos
@@ -491,4 +491,3 @@ print(z)
 {: .output}
 
 {% include links.md %}
-

--- a/_episodes/02-starting-with-data.md
+++ b/_episodes/02-starting-with-data.md
@@ -18,7 +18,7 @@ objectives:
     - "Ejecutar operaciones matemáticas básicas y calcular estadísticas descriptivas sobre datos dentro de un Pandas **Dataframe**."
     - "Crear gráficos simples."
 keypoints:
-  - "Las bibliotecas en Python son conjuntos de herramientas, funciones y estructuras de datos, agrupadas de forma conveniente para facilitar  nuestro trabajo".
+  - "Las bibliotecas en Python son conjuntos de herramientas, funciones y estructuras de datos, agrupadas de forma conveniente para facilitar  nuestro trabajo."
   - "Pandas es una librería que ofrece funcionalidades avanzadas para manejar datos tabulares, procesarlos y obtener resultados similares a los que ofrecen las hojas de cálculo."
   - "El DataFrame es la estructura de datos fundamental de Pandas, representa una tabla de datos panel con indexación integrada. Cada columna contiene los valores de una variable y cada fila un conjunto de valores de cada columna."
   - "Un índice es un vector inmutable, ordenado y divisible, que almacena las etiquetas de los ejes de todas las estructuras de Pandas. Se utiliza para agrupar y seleccionar de distintas maneras el contenido de un DataFrame."
@@ -29,9 +29,9 @@ keypoints:
 
 Podemos automatizar el proceso de manipular datos con Python. Vale la pena pasar
 tiempo escribiendo el código que haga estas tareas ya que una vez que se escribió,
-lo podemos usar una y otra vez en distintos conjuntos de datos que usen un formato 
+lo podemos usar una y otra vez en distintos conjuntos de datos que usen un formato
 similar. Esto hace a nuestros métodos fácilmente reproducibles. También resulta fácil
-compartir nuestro código con nuestros colegas y ellos pueden replicar el mismo 
+compartir nuestro código con nuestros colegas y ellos pueden replicar el mismo
 análisis.
 
 ### Comenzando en el mismo lugar
@@ -39,12 +39,12 @@ análisis.
 Para que la lección salga de la mejor manera posible, vamos a asegurarnos que todos
 estemos en el mismo directorio. Esto debería ayudarnos a evitar inconvenientes con los nombres
 de los directorios y los archivos. Navega al directorio del
-taller. Si tu estás trabajando en IPython Notebook asegurate de iniciar tu notebook 
+taller. Si tu estás trabajando en IPython Notebook asegurate de iniciar tu notebook
 en el directorio del taller.
 
 Un comentario al margen es que hay bibliotecas de Python, como [OS
 Library](https://docs.python.org/3/library/os.html), las cuales pueden trabajar con la
-estructra de directorios, sin emebargo este no es nuestro objetivo el día de hoy. 
+estructra de directorios, sin emebargo este no es nuestro objetivo el día de hoy.
 
 ### Nuestros datos
 
@@ -102,15 +102,15 @@ está instalada, puede ser usada y llamada para hacer muchas tareas.
 Una de las mejores opciones para trabajar con datos tabulares en Python es usar
 la [Python Data Analysis Library](http://pandas.pydata.org/) (alias Pandas).  La
 biblioteca Pandas provee estructuras de datos, genera gráficos de alta
-calidad con [matplotlib](http://matplotlib.org/) y se integra de buena forma 
-con otras bibliotecas que usan **arrays** de [NumPy](http://www.numpy.org/) 
+calidad con [matplotlib](http://matplotlib.org/) y se integra de buena forma
+con otras bibliotecas que usan **arrays** de [NumPy](http://www.numpy.org/)
 (la cual es otra biblioteca de Python).
 
 Python no carga todas las bibliotecas disponibles por default. Se tiene que usar
-el enunciado `import` en nuestro código para usar las funciones de la biblioteca. 
+el enunciado `import` en nuestro código para usar las funciones de la biblioteca.
 Para importar una biblioteca se usa la sintaxis `import nombreDeLaBiblioteca`. Si
 además le queremos poner un sobrenombre para acortar los comandos, se puede
-agregar `as sobrenombreAUsar`. Un ejemplo es importar la biblioteca pandas 
+agregar `as sobrenombreAUsar`. Un ejemplo es importar la biblioteca pandas
 usando su sobrenombre común `pd` como está aquí abajo.
 
 
@@ -121,19 +121,19 @@ import pandas as pd
 
 Cada vez que llamemos a una función que está en la biblioteca, se usa la sintaxis
 `NombreDeLaBiblioteca.NombreDeLaFuncion`. Agregar el nombre de la biblioteca
-con un `.` antes del nombre de la función le indica a Python donde encontrar la función. 
-En el ejemplo anterior hemos importado a Pandas como `pd`. Esto significa que no 
+con un `.` antes del nombre de la función le indica a Python donde encontrar la función.
+En el ejemplo anterior hemos importado a Pandas como `pd`. Esto significa que no
 vamos a tener que escribir `pandas` cada vez que llamemos a una función de Pandas y solo
 lo hagamos con su sobrenombre.
 
 # Leyendo datos en CSV usando Pandas
 
-Empezaremos encontrando y leyendo los datos del censo que están en 
+Empezaremos encontrando y leyendo los datos del censo que están en
 formato CSV. CSV son las siglas para _Comma-Separated Values_, valores
 separados por coma, y es una manera común de guardar datos. Otros
 símbolos pueden ser usados, te puedes encontrar valores separados por
 tabuladores, por punto y coma o por espacios en blanco. Es fácil remplazar
-un separador por otro, para usar tu aplicación. La primera línea del 
+un separador por otro, para usar tu aplicación. La primera línea del
 archivo generalmente contiene los encabezados que dicen que hay en
 cada columna. CSV (y otros separadores) hacen fácil compartir los datos y pueden
 ser importados y exportados desde distintos programas, incluyendo Microsoft Excel.
@@ -146,7 +146,7 @@ un [DataFrame](http://pandas.pydata.org/pandas-docs/stable/dsintro.html#datafram
 Un **DataFrame** es una estructura de datos con dos dimensiones en la cual se puede
 guardar datos de distintos tipos (como caractéres, enteros, valores de punto flotante,
 factores y más) en columnas. Es similar a una hoja de cálculo o una tabla de SQL o
-el `data.frame` de R. Un **DataFrame** siempre tiene un índice (con inicio en 0). El índice 
+el `data.frame` de R. Un **DataFrame** siempre tiene un índice (con inicio en 0). El índice
 refiere a la posición de un elemento en la estructura de datos.
 
 ~~~
@@ -175,12 +175,12 @@ record_id  month  day  year  plot_id species_id sex  hindfoot_length  weight
 ~~~
 {: .output}
 
-Podemos ver que se leyeron 35,549 líneas. Cada una de los líneas tiene 
+Podemos ver que se leyeron 35,549 líneas. Cada una de los líneas tiene
 9 columnas. La primera columna es el índice del DataFrame. El índice es usado
-para identificar la posición de los datos, pero no es una columna del DataFrame. 
-Parace ser que la función `read_csv`de Pandas leyó el archivo correctamente. 
-Sin embargo, no hemos salvado ningún dato en memoria por lo que no podemos 
-trabajar con estos. Necesitamos asignar el **DataFrame** a una variable. Recuerda que 
+para identificar la posición de los datos, pero no es una columna del DataFrame.
+Parace ser que la función `read_csv`de Pandas leyó el archivo correctamente.
+Sin embargo, no hemos salvado ningún dato en memoria por lo que no podemos
+trabajar con estos. Necesitamos asignar el **DataFrame** a una variable. Recuerda que
 una variable es el nombre para un valor, como `x`o `data`. Podemos crear un
 nuevo objeto con el nombre de la variable y le asignamos un valor usando `=`.
 
@@ -203,7 +203,7 @@ surveys_df
 el cual imprime los contenidos como anteriormente.
 
 Nota: si la salida es más ancha que la pantalla de teminal al imprimirlo se verá algo
-distinto conforme el gran conjunto de datos pasa. Se podría ver simplemente la 
+distinto conforme el gran conjunto de datos pasa. Se podría ver simplemente la
 última columna de los datos:
 
 ~~~
@@ -256,9 +256,9 @@ distinto conforme el gran conjunto de datos pasa. Se podría ver simplemente la
 ~~~
 {: .output}
 
-No temas, todos los datos están ahí, si tu navegas hacía arriba de tu terminal. 
+No temas, todos los datos están ahí, si tu navegas hacía arriba de tu terminal.
 Seleccionemos solo algunas de las líneas, esto hara más facil que la salida quepa en
-una terminal, se puede ver que Pandas formateo los datos de tal manera que quepan 
+una terminal, se puede ver que Pandas formateo los datos de tal manera que quepan
 en la pantalla:
 
 ~~~
@@ -299,7 +299,7 @@ type(surveys_df)
 Como podíamos esperar, es un **DataFrame** (o, usando el nombre completo por
 el cual Python usa internamente, un  `pandas.core.frame.DataFrame`).
 
-¿Qué tipo de cosas `surveys_df` contiene? Los **DataFrame** tienen un atributo 
+¿Qué tipo de cosas `surveys_df` contiene? Los **DataFrame** tienen un atributo
 llamado `dtypes` que contesta esta pregunta:
 
 ~~~
@@ -321,9 +321,9 @@ dtype: object
 {: .output}
 
 Todos los valores de una columna tienen el mismo tipo. Por ejemplo, months tienen
-el tipo `int64`, el cual es un tipo de entero. Las celdas en la columna de mes 
-no pueden tener valores fraccionarios, pero las columnas de `weight` y 
-`hindfoot_length` pueden, ya que son de tupo `float64`. El tipo `object` no tiene 
+el tipo `int64`, el cual es un tipo de entero. Las celdas en la columna de mes
+no pueden tener valores fraccionarios, pero las columnas de `weight` y
+`hindfoot_length` pueden, ya que son de tupo `float64`. El tipo `object` no tiene
 un nombre muy útil, pero en ete caso representa una palabra (como 'M' y  'F' en
 el caso del sexo).
 
@@ -336,7 +336,7 @@ usando los atributos y métodos que proveé el objeto DataFrame.
 
 Para accesar a un atributo, se usa el nombre del objeto **DataFrame** seguido
 del nombre del atributo `df_object.attribute`. Usando el **DataFrame** `surveys_df`
-y el atributo `columns`, un índice de todos los nombres de las columnas en 
+y el atributo `columns`, un índice de todos los nombres de las columnas en
 el **DataFrame** puede ser accesado con `surveys_df.columns`.
 
 Métodos son llamados de la misma manera usando la sintáxis `df_object.method()`.
@@ -366,7 +366,7 @@ Echemos un ojo a los datos usando este.
 Hemos leídos los datos en Python. Ahora calculemos algunas estadísticas para
 entender un poco de los datos con los que estamos trabajando. Podríamos  querer
 saber cuántos animales fueron colectados en cada sitio, o cuántos de cada especie
-fueron capturados. Podemos calcular estas estadísticas rápidamente usando grupos. 
+fueron capturados. Podemos calcular estas estadísticas rápidamente usando grupos.
 Pero antes tenemos que saber como los queremos argupar.
 
 Empezemos a explorar los datos:
@@ -408,7 +408,7 @@ array(['NL', 'DM', 'PF', 'PE', 'DS', 'PP', 'SH', 'OT', 'DO', 'OX', 'SS',
 > ## Reto - Estadísticas
 >
 > 1. Crear una lista de los IDs de los sitios ("plot_id") que están en los datos del censo.
->    Llamamemos a esta lista `site_names`. ¿Cuántos sitios hay en los datos?, ¿cuántas 
+>    Llamamemos a esta lista `site_names`. ¿Cuántos sitios hay en los datos?, ¿cuántas
 >   especies hay en los datos?
 >
 > 2. ¿Cuál es la diferencia entre `len(site_names)` y`surveys_df['plot_id'].nunique()`?
@@ -416,7 +416,7 @@ array(['NL', 'DM', 'PF', 'PE', 'DS', 'PP', 'SH', 'OT', 'DO', 'OX', 'SS',
 
 # Grupos en Pandas
 
-En algunas ocasiones queremos calcular estadísticas de datos agrupados por 
+En algunas ocasiones queremos calcular estadísticas de datos agrupados por
 subconjuntos o atributos de nuestros datos. Por ejemplo, si queremos calcular el
 promedio de peso de nuestros individuos por sitio.
 
@@ -464,8 +464,8 @@ grouped_data = surveys_df.groupby('sex')
 {: .language-python}
 
 La **función `describe` de Pandas** regresa estadísticas descriptivas incluyendo:
-media, meadiana, máx, mín, std y conteos para una columna en particular de los 
-datos. La función `describe` solo regresa los valores de estas estadísticas para las 
+media, meadiana, máx, mín, std y conteos para una columna en particular de los
+datos. La función `describe` solo regresa los valores de estas estadísticas para las
 columnas numéricas.
 
 ~~~
@@ -503,7 +503,7 @@ estadísticas descriptivas.
 >   - `grouped_data2 = surveys_df.groupby(['plot_id','sex'])`
 >   - `grouped_data2.mean()`
 > 3. Calcula las estadísticas descriptivas del peso para cada sitio. Sugerencia:
->    puedes usar la siguiente sintaxis para solo crear las estadísticas para una 
+>    puedes usar la siguiente sintaxis para solo crear las estadísticas para una
 >   columna de tus datos
 >   `by_site['weight'].describe()`
 >
@@ -529,7 +529,7 @@ estadísticas descriptivas.
 
 ## Creando estadísticas de conteos rapidamente con Pandas
 
-Ahora contemos el número de muestras de cada especie. Podemos hacer esto 
+Ahora contemos el número de muestras de cada especie. Podemos hacer esto
 de dsitintas maneras, pero usaremos `groupby` combinada con **el método `count()`**.
 
 ~~~
@@ -550,14 +550,14 @@ surveys_df.groupby('species_id')['record_id'].count()['DO']
 >
 > ¿Qué otra manera hay de crear una lista de especies y asociarle `count` de las
 >  muestras  de los datos? Sugerencia: puedes hacer ejecutar las funciones
->  `count`, `min`, etc. en un **DataFrame** groupby de la misma manera de la que 
+>  `count`, `min`, etc. en un **DataFrame** groupby de la misma manera de la que
 >  se hace en un DataFrame
 {: .challenge}
 
 ## Funciones básicas de matemáticas
 
 Si nosotros quisieramos, se puede hacer operaciones en una columna de los
-datos. Como ejemplo multipliquemos todos los valores de peso por 2. Un uso 
+datos. Como ejemplo multipliquemos todos los valores de peso por 2. Un uso
 más útil podría ser normalizar los datos con la media, área o algñun otro valor
 calculado de nuestros datos.
 
@@ -600,15 +600,15 @@ total_count.plot(kind='bar');
 
 > ## Reto de graficación final
 >
-> Crea una gráfica de barras apiladas con el peso en el eje Y, y la variable de 
+> Crea una gráfica de barras apiladas con el peso en el eje Y, y la variable de
 > apilamiento que sea el sexo. La gráfica debe mostrar el peso total por sexo
 > para cada sitio. Algúnos tips que te pueden ayudar a resolver el reto son los
 > siguientes:
 >
 > * [Para mayor información en gráfica con Pandas, visita la siguiente liga.](http://pandas.pydata.org/pandas-docs/stable/visualization.html#basic-plotting-plot)
-> * Puedes usar el siguiente código para crear una gráficad de barras apiladas pero 
+> * Puedes usar el siguiente código para crear una gráficad de barras apiladas pero
 >    los datos para apilar deben de estar en distintas columnas. Aquí hay un pequeño
->    ejemplo con algunos datos donde 'a', 'b' y 'c' son los grupos, y 'one' y 'two' son los 
+>    ejemplo con algunos datos donde 'a', 'b' y 'c' son los grupos, y 'one' y 'two' son los
 >    subgrupos.
 >
 > ~~~
@@ -641,7 +641,7 @@ total_count.plot(kind='bar');
 >
 > * Podemos usar el método `.unstack()` para transformar los datos agrupados en
 >    columnas para cada gráfica. Intenta ejecutar `.unstack()` en algún DataFrame
->    anterior y observa a que lleva. 
+>    anterior y observa a que lleva.
 >
 > Empieza transformando los datos agrupados (por sitio y sexo) en una disposición desapilada
 > entonces crea una gráfica apilada.
@@ -719,4 +719,3 @@ total_count.plot(kind='bar');
 {: .challenge}
 
 {% include links.md %}
-

--- a/_episodes/03-index-slice-subset.md
+++ b/_episodes/03-index-slice-subset.md
@@ -19,10 +19,10 @@ keypoints:
     - "En Python, fragmentos de datos pueden ser accedidos usando índices, cortes, encabezados de columnas, y subconjuntos basados en condiciones."
     - "Python usa indexación base-0, en la cual el primer elemento de una lista, tupla o cualquier otra estructura de datos tiene un índice de 0."
     - "'Pandas' permite usar procedimientos comunes de exploración de datos como indexación de datos, cortes y creación de subconjuntos basados en condiciones."
-    
+
 ---
 
-En la lección 01, leímos un archivo CSV y cargamos los datos en un  pandas **DataFrame**. 
+En la lección 01, leímos un archivo CSV y cargamos los datos en un  pandas **DataFrame**.
 Aprendimos:
 
 - como guardar el **DataFrame** en un objeto,
@@ -53,14 +53,14 @@ surveys_df = pd.read_csv("data/surveys.csv")
 
 ## Indexando y Fragmentando en Python
 
-A menudo necesitamos trabajar con subconjuntos de un objeto **DataFrame**. Existen diferentes 
-maneras de lograr esto, incluyendo: usando etiquetas (encabezados de columnas), rangos numéricos, 
+A menudo necesitamos trabajar con subconjuntos de un objeto **DataFrame**. Existen diferentes
+maneras de lograr esto, incluyendo: usando etiquetas (encabezados de columnas), rangos numéricos,
 o índices de localizaciones específicas x,y.
 
 ## Seleccionando datos mediante el uso de Etiquetas (Encabezados de Columnas)
 
-Utilizamos corchetes `[]` para seleccionar un subconjunto de un objeto en Python. Por ejemplo, 
-podemos seleccionar todos los datos de una columna llamada `species_id`  del `surveys_df` **DataFrame** 
+Utilizamos corchetes `[]` para seleccionar un subconjunto de un objeto en Python. Por ejemplo,
+podemos seleccionar todos los datos de una columna llamada `species_id`  del `surveys_df` **DataFrame**
 usando el nombre de la columna. Existen dos maneras de hacer esto:
 
 ~~~
@@ -73,7 +73,7 @@ surveys_df.species_id
 ~~~
 {: .language-python}
 
-También podemos crear un nuevo objeto que contiene solamente los datos de la 
+También podemos crear un nuevo objeto que contiene solamente los datos de la
 columna `species_id` de la siguiente manera:
 
 ~~~
@@ -82,10 +82,10 @@ surveys_species = surveys_df['species_id']
 ~~~
 {: .language-python}
 
-También podemos pasar una lista de nombres de columnas, a manera de índice para seleccionar las columnas en ese orden. 
+También podemos pasar una lista de nombres de columnas, a manera de índice para seleccionar las columnas en ese orden.
 Esto es útil cuando necesitamos reorganizar nuestros datos.
 
-**NOTA:** Si el nombre de una columna no esta incluido en el `DataFrame`, 
+**NOTA:** Si el nombre de una columna no esta incluido en el `DataFrame`,
 se producirá una excepción (error).
 
 ~~~
@@ -100,7 +100,7 @@ surveys_df['speciess']
 ~~~
 {: .language-python}
 
-Python nos informa que tipo de error es en el rastreo, en la parte inferior dice `KeyError: 'speciess'` lo que significa 
+Python nos informa que tipo de error es en el rastreo, en la parte inferior dice `KeyError: 'speciess'` lo que significa
 que `speciess` no es un nombre de columna (o **Key** que está relacionado con el diccionario de tipo de datos de Python).
 
 ## Extrayendo subconjuntos basados en rangos: Segmentando
@@ -109,7 +109,7 @@ que `speciess` no es un nombre de columna (o **Key** que está relacionado con e
 
 Recordemos que Python usa indexación en base-0.
 Esto quiere decir que el primer elemento en un objeto esta localizado en la posición 0.
-Esto es diferente de otros lenguajes como R y Matlab que indexan elementos dentro 
+Esto es diferente de otros lenguajes como R y Matlab que indexan elementos dentro
 de objetos iniciando en 1.
 
 ~~~
@@ -151,10 +151,10 @@ a = [1, 2, 3, 4, 5]
 
 ## Segmentando Subconjuntos de Filas en Python
 
-La segmentación utilizando el operador `[]` selecciona un conjunto de filas y/o columnas de 
-un **DataFrame**. Para segmentar un conjunto de filas, usa la siguiente sintaxis: `data[start:stop]`. 
-Cuando se hace segmentación en pandas, el límite inicial (**start**) se incluye en los datos de salida. 
-El límite final (**stop**) es un paso MÁS ALLÁ de la fila que desea seleccionar. 
+La segmentación utilizando el operador `[]` selecciona un conjunto de filas y/o columnas de
+un **DataFrame**. Para segmentar un conjunto de filas, usa la siguiente sintaxis: `data[start:stop]`.
+Cuando se hace segmentación en pandas, el límite inicial (**start**) se incluye en los datos de salida.
+El límite final (**stop**) es un paso MÁS ALLÁ de la fila que desea seleccionar.
 Así que si deseas seleccionar las filas 0, 1 y 2, tu código se vería así:
 
 ~~~
@@ -163,7 +163,7 @@ surveys_df[0:3]
 ~~~
 {: .language-python}
 
-El límite final en Python es diferente del que puedes estar acostumbrado a usar 
+El límite final en Python es diferente del que puedes estar acostumbrado a usar
 en Lenguajes como Matlab y R.
 
 ~~~
@@ -178,7 +178,7 @@ surveys_df[-1:]
 
 También podemos reasignar valores dentro de subconjuntos de nuestro **DataFrame**.
 
-Pero antes de hacerlo, veamos la diferencia entre el concepto de copiar objetos y el 
+Pero antes de hacerlo, veamos la diferencia entre el concepto de copiar objetos y el
 concepto de referenciar objetos en Python.
 
 ## Copiar Objetos vs Referenciar Objetos en Python
@@ -194,11 +194,11 @@ ref_surveys_df = surveys_df
 ~~~
 {: .language-python}
 
-Puedes pensar que el código `ref_surveys_df = surveys_df` crea una copia nueva y 
-distinta de objeto **DataFrame** `surveys_df`. Sin embargo, usar el operador `=` en 
-una instrucción simple de la forma `y = x` **no** crea una copia de nuestro **DataFrame**. 
-En lugar de esto, `y = x` crea una variable nueva `y` que hace referencia al **mismo** 
-objeto al que `x` hace referencia. Para decirlo de otra manera, solamente hay **un** 
+Puedes pensar que el código `ref_surveys_df = surveys_df` crea una copia nueva y
+distinta de objeto **DataFrame** `surveys_df`. Sin embargo, usar el operador `=` en
+una instrucción simple de la forma `y = x` **no** crea una copia de nuestro **DataFrame**.
+En lugar de esto, `y = x` crea una variable nueva `y` que hace referencia al **mismo**
+objeto al que `x` hace referencia. Para decirlo de otra manera, solamente hay **un**
 objeto (el **DataFrame**), y ambos objetos `x` y `y` hacen referencia a él.
 
 En contraste, el método `copy()` de un **DataFrame** crea una copia verdadera del
@@ -227,9 +227,9 @@ surveys_df.head()
 ¿Cuál es la diferencia entre estos dos **DataFrames**?
 
 Cuando asignamos a las tres primeras filas el valor de `0` usando el **DataFrame** `ref_surveys_df`,
-el **DataFrame** `surveys_df` también es modificado. Recuerda que creamos el objeto `ref_survey_df` 
-arriba usando la instrucción `ref_survey_df = surveys_df`. Por lo tanto `surveys_df` y `ref_surveys_df` hacen 
-referencia exactamente al mismo objeto **DataFrame**. Si cualquiera de los dos objetos (`ref_survey_df`, `surveys_df`) 
+el **DataFrame** `surveys_df` también es modificado. Recuerda que creamos el objeto `ref_survey_df`
+arriba usando la instrucción `ref_survey_df = surveys_df`. Por lo tanto `surveys_df` y `ref_surveys_df` hacen
+referencia exactamente al mismo objeto **DataFrame**. Si cualquiera de los dos objetos (`ref_survey_df`, `surveys_df`)
 es modificado, el otro objeto va a observar los mismos cambios.
 
 **Revisar y Recapitular**:
@@ -357,7 +357,7 @@ selecciona el elemento ubicado en la intersección de la tercera fila (índice 2
 
 ## Creando subconjuntos de datos mediante el filtrado por criterios
 
-También podemos seleccionar un subconjunto de nuestros datos, mediante el filtrado de la data original, usando algún criterio. 
+También podemos seleccionar un subconjunto de nuestros datos, mediante el filtrado de la data original, usando algún criterio.
 Por ejemplo, podemos seleccionar todas las filas que tienen el valor de 2002 en la columna `year`:
 
 ~~~
@@ -467,10 +467,10 @@ Para crear una máscara booleana:
 - Establece el criterio a ser evaluado como `True` o `False` (ej. `values > 5 = True`)
 - Python evaluará cada valor en el objeto para determinar si
   el valor cumple el criterio (`True`) o no lo cumple (`False`).
-- Python crea un objeto de salida que es de la misma forma que el objeto 
+- Python crea un objeto de salida que es de la misma forma que el objeto
   original, pero con un valor `True` o `False` por cada índice según corresponda.
 
-Intentémoslo. Vamos a identificar todos los lugares en los datos de `survey` que son `null` (que no existen o son NaN). 
+Intentémoslo. Vamos a identificar todos los lugares en los datos de `survey` que son `null` (que no existen o son NaN).
 Podemos usar el método `isnull` para lograrlo.
 El método `isnull` va a comparar cada celda con un valor `null`. Si un elemento
 tiene un valor `null`, se le asignará un nuevo valor de `True` en el objeto de salida.
@@ -529,8 +529,7 @@ pidiendo a Python que seleccione aquellas filas que tienen un valor de `NaN` en 
 > 2. Crea un nuevo objeto `DataFrame` que contenga solo observaciones cuyos valores en la columna `sex` sean `male`
 >   o `female` y en los cuales el valor de `weight` sea mayor que 0. Luego, crea un gráfico de barra apiladas
 >   del promedio de `weight`,  por parcela, con valores `male` versus `female` apilados por cada parcela.
->   
+>
 {: .challenge}
 
 {% include links.md %}
-

--- a/_episodes/04-data-types-and-format.md
+++ b/_episodes/04-data-types-and-format.md
@@ -18,8 +18,8 @@ keypoints:
     para datos textuales."
    - "Una columna en un DataFrame sólo puede tener un tipo de datos."
    - "El tipo de datos de la columna de un DataFrame puede ser comprobado usando `dtype`."
-   - "Es necesario tomar decisiones conscientes sobre cómo manejar los datos faltantes".
-   - "Un DataFrame puede ser guardado en un archivo CSV usando la función `to_csv`".
+   - "Es necesario tomar decisiones conscientes sobre cómo manejar los datos faltantes."
+   - "Un DataFrame puede ser guardado en un archivo CSV usando la función `to_csv`."
 ---
 
 El formato de columnas y filas individuales afectará el análisis realizado en
@@ -154,9 +154,9 @@ dtype: object
 
 Ten en cuenta que la mayoría de las columnas en nuestros datos de encuesta son
 del tipo `int64`. Esto significa que son enteros de 64 bits. Pero la columna de
-peso (weight) es un valor de punto flotante o `float`, lo que significa que contiene 
+peso (weight) es un valor de punto flotante o `float`, lo que significa que contiene
 decimales. Las columnas `species_id` y `sex` son objetos, lo cual significa que
-contienen secuencias de caracteres `string`. 
+contienen secuencias de caracteres `string`.
 
 ## Trabajando con **integers** y **floats**
 

--- a/_episodes/05-merging-data.md
+++ b/_episodes/05-merging-data.md
@@ -10,7 +10,7 @@ objectives:
   - "Combinar dos DataFrames usando un ID único encontrado en ambos DataFrames."
   - "Unir DataFrames usando campos comunes (unión por claves)."
 keypoints:
-    - "Podemos usar la función `concat` en pandas para agregar columnas o filas de un 
+    - "Podemos usar la función `concat` en pandas para agregar columnas o filas de un
     DataFrame a otro."
     - "Se pueden combinar DataFrames en base a columnas en cada dataset que contienen
     valores comunes (un ID única común), esta combinación utilizando un campo
@@ -73,7 +73,7 @@ Ten en cuenta que el método `read_csv` que usamos puede tomar opciones adiciona
 
 # Concatenando DataFrames
 
-Podemos usar la función `concat` en pandas para agregar columnas o filas de un __DataFrame__ a otro. Tomemos dos subconjuntos de nuestros datos para ver cómo esto trabaja. 
+Podemos usar la función `concat` en pandas para agregar columnas o filas de un __DataFrame__ a otro. Tomemos dos subconjuntos de nuestros datos para ver cómo esto trabaja.
 
 ~~~
 # Lee las primeras 10 líneas de la tabla de encuestas.
@@ -123,7 +123,7 @@ new_output = pd.read_csv('data_output/out.csv', keep_default_na=False, na_values
 
 > ## Challenge - Combine Data
 >
-> En la carpeta de datos, hay dos archivos de datos de encuestas: `survey2001.csv` y `survey2002.csv`. 
+> En la carpeta de datos, hay dos archivos de datos de encuestas: `survey2001.csv` y `survey2002.csv`.
 > Lee los datos en Python y combina los archivos para hacer un __DataFrame__ nuevo.
 > Crea una gráfica del peso promedio de la parcela, `plot_id`, por año agrupada por sexo. Exporta tus resultados como CSV y asegúrate de que se lean correctamente en Python.
 {: .challenge}
@@ -179,7 +179,7 @@ Index([u'record_id', u'month', u'day', u'year', u'plot_id', u'species_id',
 ~~~
 {: .language-python}
 
-En nuestro ejemplo, la clave de unión es la columna que contiene el identificador de especie de dos letras, que se llama `species_id`. 
+En nuestro ejemplo, la clave de unión es la columna que contiene el identificador de especie de dos letras, que se llama `species_id`.
 
 Ahora que conocemos los campos con los atributos de ID de especies comunes en cada __DataFrame__, estamos casi listos para unir nuestros datos. Sin embargo, porque hay
 [diferentes tipos de uniones](http://blog.codinghorror.com/a-visual-explanation-of-sql-joins/), también debemos decidir qué tipo de unión tiene sentido para nuestro análisis.
@@ -198,7 +198,7 @@ la opción por defecto:
 
 ~~~
 merged_inner = pd.merge(left=survey_sub,right=species_sub, left_on='species_id', right_on='species_id')
-# En este caso, `species_id` es el único nombre de columna en los dos __DataFrames__, entonces si omitimos 
+# En este caso, `species_id` es el único nombre de columna en los dos __DataFrames__, entonces si omitimos
 # los argumentos `left_on` y `right_on` todavía obtendríamos el mismo resultado
 
 # ¿Cuál es el tamaño de los datos en el resultado?

--- a/_episodes/06-loops-and-functions.md
+++ b/_episodes/06-loops-and-functions.md
@@ -15,15 +15,15 @@ keypoints:
    - "Los bucles nos permiten repetir una serie de acciones un número dado de veces
     o mientras una condición es cierta."
    - "Podemos automatizar tareas que se deben repetir un número predefinido de veces
-    utilizando bucles `for`"
+    utilizando bucles `for`."
    - "Una tarea de automatización típica en programación es generar secuencias de
     archivos con nombres distinos que siguen un patrón, esto se puede realizar
     fácilmente manipulando cadenas de caracteres con el nombre de los archivos
     dentro de bucles de repetición a medida que se van creando."
    - "Es conveniente definir funciones para establecer bloques de código reutilizables.
     Las funciones se pueden diseñar para que acepten argumentos de entradas para
-    generalizar su funcionalidad y devolver distintos tipos de resultados." 
-   - "Las sentencias `if` permiten elegir cuales bloques de código ejecutar según según se cumplan o no distintas condiciones".
+    generalizar su funcionalidad y devolver distintos tipos de resultados."
+   - "Las sentencias `if` permiten elegir cuales bloques de código ejecutar según según se cumplan o no distintas condiciones."
 ---
 
 Hasta este momento, hemos usado Python y la librería Pandas para explorar y
@@ -112,7 +112,7 @@ iteración. La palabra clave `pass` en el cuerpo del bucle significa solamente
 >
 > 2. Reescribe el bucle de tal forma que los animales estén separados por comas
 >    y no por una línea nueva.
->    (Pista: Puedes concatenar cadenas de caracteres usando el signo más. Por 
+>    (Pista: Puedes concatenar cadenas de caracteres usando el signo más. Por
 >    ejemplo, `print(string1 + string2)` resulta en 'string1string2').
 {: .challenge}
 
@@ -505,7 +505,7 @@ cambiar su salida.
 >    los contenidos de directorios.
 > 4. Explora qué sucede cuando las variables son declaradas dentro de cada una
 >    de las funciones versus en el cuerpo principal de tu código (lo que está
->    sin indentar). ¿Cuál es el alcance de las variables (es decir, dónde son 
+>    sin indentar). ¿Cuál es el alcance de las variables (es decir, dónde son
 >    visibles)?, ¿qué ocurre si tienen el mismo nombre pero valores diferentes?
 {: .challenge}
 
@@ -730,4 +730,3 @@ One keyword, default start:	1977 1993
 {: .challenge}
 
 {% include links.md %}
-

--- a/_episodes/08-putting-it-all-together.md
+++ b/_episodes/08-putting-it-all-together.md
@@ -11,7 +11,7 @@ objectives:
 keypoints:
      - "Matplotlib es el motor detrás de los gráficos creados con plotnine y Pandas."
      - "La filosofía de los gráficos de matplotlib, basada en objetos, permite la personalización detallada de los gráficos una vez creados."
-     - "Es posible exportar gráficos a un archivo usando el método `savefig`." 
+     - "Es posible exportar gráficos a un archivo usando el método `savefig`."
 ---
 
 
@@ -298,4 +298,3 @@ bien guárdalo como un archivo de texto con extensión `.py` y ejecútalo en la 
 {: .challenge}
 
 {% include links.md %}
-

--- a/_episodes/09-working-with-sql.md
+++ b/_episodes/09-working-with-sql.md
@@ -14,7 +14,7 @@ objectives:
 keypoints:
     - "Se puede crear una conexión con `sqlite3.connect()`, y luego establecer un cursor para consultas con `.cursor()`."
     - "Es posible ejecutar consultas usando `.execute()`."
-    - "Puedes usar la función `.read_sql_query()` de Pandas para extraer datos 
+    - "Puedes usar la función `.read_sql_query()` de Pandas para extraer datos
     directamente de un DataFrame."
     - "Se pueden escribir los datos de un DataFrame a una nueva tabla en SQLite usando `.to_sql()`."
     - "Al final, no olvides cerrar la puerta de la conexión usando el comando `.close()`."
@@ -84,7 +84,7 @@ con.close()
 
 ##  Accesando datos almacenados en SQLite usando Python y Pandas
 
-Usando Pandas, podemos importar los resultados de una consulta en SQLite a un *DataFrame*. Nota que puedes usar los mismos comandos o sintaxis que usamos en la lección SQLite. 
+Usando Pandas, podemos importar los resultados de una consulta en SQLite a un *DataFrame*. Nota que puedes usar los mismos comandos o sintaxis que usamos en la lección SQLite.
 
 Por ejemplo para usar Pandas y SQLite:
 
@@ -117,7 +117,7 @@ Almacenar datos en una base de datos SQLite incrementa sustancialmente el rendim
 
 > ## Desafío - SQL
 >
-> 1. Crea una consulta que contenga datos de encuestas recopiladas entre 1998 y 2001 
+> 1. Crea una consulta que contenga datos de encuestas recopiladas entre 1998 y 2001
 > para observaciones de sexo "masculino" o "femenino" que incluyan el género y la especie de la observación,
 > y el tipo de sitio de la muestra. ¿Cuántos registros regresa la consulta?
 >
@@ -156,7 +156,7 @@ con.close()
 >
 > 1. Para cada uno de los desafíos del bloque anterior, modifica tu codigo para guardar los resultados en sus propias tablas en el portal de base de datos.
 >
-> 2. ¿Por qué razones tú preferirías guardar los resultados de tus consultas nuevamente en la base de datos? 
+> 2. ¿Por qué razones tú preferirías guardar los resultados de tus consultas nuevamente en la base de datos?
 > ¿Por qué razones preferirías evitar hacer esto?
 {: .challenge}
 


### PR DESCRIPTION
`"` and `.` were misordered in the front matter of a few pages, causing the pages to build with title, objectives, key points etc missing. (See https://datacarpentry.org/python-ecology-lesson-es/01-short-introduction-to-Python/index.html as an example.)

This PR fixes these errors to get the pages displaying correctly again. 