### PR TITLE
set lang to es

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,9 @@ branch: 'main'
 # Who to contact if there are any issues
 contact: 'team@carpentries.org'
 
+# Language of lesson
+lang: 'es'
+
 # Navigation ------------------------------------------------
 #
 # Use the following menu items to specify the order of


### PR DESCRIPTION
Sets `lang` variable in config.yml to 'es'. Using this setting makes sandpaper look in the /po/ directory for a file called `R-es.po` and uses the translated strings in that file for menu items etc. 

Screenshot of lesson front page before setting `lang` variable to 'es':
<img width="1353" alt="Screenshot 2024-04-16 at 9 12 02 AM" src="https://github.com/datacarpentry/python-ecology-lesson-es/assets/19176319/bda4ff81-ef0d-462d-8169-ca91024f4793">

Screenshot of lesson front page after setting `lang` variable to 'es':
<img width="1375" alt="Screenshot 2024-04-16 at 9 12 16 AM" src="https://github.com/datacarpentry/python-ecology-lesson-es/assets/19176319/4fd07115-3e86-4c8a-b158-d0d8e35551bc">
