### PR TITLE
Enable Matomo analytics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,5 +87,5 @@ profiles:
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
 
-
+analytics: carpentries
 url: 'https://datacarpentry.org/python-ecology-lesson-es'


### PR DESCRIPTION
Somehow this lesson was missed when we were adding Matomo tracking for web analytics. This PR enables the tracking so we can tell you how many visits the site receives in 2025.